### PR TITLE
Redo settings to always load from disk

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from typing import TypedDict, cast
-from . import paths
+
 import toml
+from config import paths
 
 
 class SettingsInterface(TypedDict):
@@ -20,8 +21,13 @@ class Settings:
 
     @classmethod
     def load(cls) -> "Settings":
-        data = cast(SettingsInterface, toml.load(paths.CONFIG_DIR / "settings.toml"))
+        data = toml.load(paths.CONFIG_DIR / "settings.toml")
+        data = cast(SettingsInterface, data)
         return Settings(data)
+
+    def dump(self) -> None:
+        data = dict(series_dirs=[str(x) for x in self.series_dirs])
+        toml.dump(data, open(paths.CONFIG_DIR / "settings.toml", "w"))
 
     def validate(self) -> bool:
         """

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,3 +1,0 @@
-from . import _settings
-
-settings = _settings.Settings.load()


### PR DESCRIPTION
Resolves https://github.com/LiteralGenie/mu_reader_server/issues/5.

So the plan is to always load the settings from disk whenever they're referenced. Loading from disk is a bit gross, but without setting up an in-mem cache like redis, sharing globals (memory) across gunicorn workers is impossible.

Any "hooks" that need to re-run when a setting changes will have to be done by the function changing it. (eg when the user PATCHs a new series directory, a scan of that folder needs to be initiated, maybe as a background task)